### PR TITLE
[iOS] Run react bridge reload event handler on main thread

### DIFF
--- a/ios/RCCManager.m
+++ b/ios/RCCManager.m
@@ -58,10 +58,12 @@
 }
 
 -(void)onRNReload {
-    id<UIApplicationDelegate> appDelegate = [UIApplication sharedApplication].delegate;
-    appDelegate.window.rootViewController = nil;
-    [self setAppStyle:nil];
-    [self clearModuleRegistry];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        id<UIApplicationDelegate> appDelegate = [UIApplication sharedApplication].delegate;
+        appDelegate.window.rootViewController = nil;
+        [self setAppStyle:nil];
+        [self clearModuleRegistry];
+    });
 }
 
 -(void)registerController:(UIViewController*)controller componentId:(NSString*)componentId componentType:(NSString*)componentType {


### PR DESCRIPTION
we need this since the handler messes with the UI, and if we do that off the main thread, the UI is left in an funky state that could lead to undefined behavior including crashes. 

Not sure how this works on the main fork, maybe they just ignore the error? Or never hit this block of code?