### PR TITLE
Fix android crash: destroy views on catalyst instance destroy

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
@@ -129,4 +129,8 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
         view.setBackgroundColor(Color.WHITE);
         setContentView(view);
     }
+
+    public void onCatalystInstanceDestroy() {
+        runOnUiThread(() -> navigator.destroyViews());
+    }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/NavigationModule.java
@@ -2,6 +2,7 @@ package com.reactnativenavigation.react;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.Arguments;
@@ -178,5 +179,15 @@ public class NavigationModule extends ReactContextBaseJavaModule {
 
     private NavigationActivity activity() {
         return (NavigationActivity) getCurrentActivity();
+    }
+
+    @Override
+    public void onCatalystInstanceDestroy() {
+        try {
+            activity().onCatalystInstanceDestroy();
+        } catch (NullPointerException | ClassCastException e) {
+            Log.e(NAME, "onCatalystInstanceDestroy(): activity null or unexpected class type", e);
+        }
+        super.onCatalystInstanceDestroy();
     }
 }


### PR DESCRIPTION
this fixes redscreen/crash when `ReactInstaceManager#recreateReactContextInBackground()` is called