### PR TITLE
Android auto-blur option

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/ModalOptions.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/ModalOptions.java
@@ -1,29 +1,40 @@
 package com.reactnativenavigation.parse;
 
+import android.support.annotation.NonNull;
+
+import com.reactnativenavigation.parse.params.Bool;
+import com.reactnativenavigation.parse.params.NullBool;
+import com.reactnativenavigation.parse.parsers.BoolParser;
+
 import org.json.JSONObject;
 
 public class ModalOptions {
 
-    public static ModalOptions parse(JSONObject json) {
+    public static ModalOptions parse(final JSONObject json) {
         ModalOptions options = new ModalOptions();
         if (json == null) return options;
 
         options.presentationStyle = ModalPresentationStyle.fromString(json.optString("modalPresentationStyle"));
+        options.blurOnUnmount = BoolParser.parse(json, "blurOnUnmount");
 
         return options;
     }
 
     public ModalPresentationStyle presentationStyle = ModalPresentationStyle.Unspecified;
+    public @NonNull Bool blurOnUnmount = new NullBool();
 
-    public void mergeWith(ModalOptions other) {
-        if (other.hasValue()) presentationStyle = other.presentationStyle;
+    public void mergeWith(final ModalOptions other) {
+        if (other.presentationStyleHasValue()) presentationStyle = other.presentationStyle;
+        if (other.blurOnUnmount.hasValue()) blurOnUnmount = other.blurOnUnmount;
     }
 
-    private boolean hasValue() {
+    private boolean presentationStyleHasValue() {
         return presentationStyle != ModalPresentationStyle.Unspecified;
     }
 
-    public void mergeWithDefault(ModalOptions defaultOptions) {
-        if (!hasValue()) presentationStyle = defaultOptions.presentationStyle;
+    public void mergeWithDefault(final ModalOptions defaultOptions) {
+        if (!presentationStyleHasValue()) presentationStyle = defaultOptions.presentationStyle;
+        if (!blurOnUnmount.hasValue()) blurOnUnmount = defaultOptions.blurOnUnmount;
     }
+
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/parse/parsers/BoolParser.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/parse/parsers/BoolParser.java
@@ -1,12 +1,14 @@
 package com.reactnativenavigation.parse.parsers;
 
+import android.support.annotation.NonNull;
+
 import com.reactnativenavigation.parse.params.Bool;
 import com.reactnativenavigation.parse.params.NullBool;
 
 import org.json.JSONObject;
 
 public class BoolParser {
-    public static Bool parse(JSONObject json, String bool) {
+    public static @NonNull Bool parse(@NonNull JSONObject json, @NonNull String bool) {
         return json.has(bool) ? new Bool(json.optBoolean(bool)) : new NullBool();
     }
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ComponentViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ComponentViewController.java
@@ -2,6 +2,7 @@ package com.reactnativenavigation.viewcontrollers;
 
 import android.app.Activity;
 import android.support.annotation.NonNull;
+import android.view.View;
 
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.presentation.OptionsPresenter;
@@ -70,5 +71,22 @@ public class ComponentViewController extends ChildController<ComponentLayout> {
 
     ReactComponent getComponent() {
         return view;
+    }
+
+    @Override
+    public void destroy() {
+        final boolean blurOnUnmount = options != null && options.modal.blurOnUnmount.isTrue();
+        if (blurOnUnmount) {
+            blurActivityFocus();
+        }
+        super.destroy();
+    }
+
+    private void blurActivityFocus() {
+        final Activity activity = getActivity();
+        final View focusView = activity != null ? activity.getCurrentFocus() : null;
+        if (focusView != null) {
+            focusView.clearFocus();
+        }
     }
 }


### PR DESCRIPTION
This PR adds an Android specific boolean flag `blurOnUnmount` that can be passed as part of the options when pushing or popping a component; when this flag is `true` for a component, any input views that have focus on said component will be blurred when the component is getting destroyed, which has the effect of dismissing the keyboard when the component is unmounted.

The reason this functionality is behind a flag and not automatically enabled by default is because the appearing component will not be able to focus an input if the disappearing component performs the auto-blur functionality. Its important to be aware of this limitation to avoid weird and seemingly inexplicable behavior. If this limitation becomes a blocker, it might be possible to work around it by futzing with the ordering of calls to the appearing and disappearing components, however I didn't know for sure this would be the case, so it seemed safer to put the functionality behind a option flag and cross the "always-on" bridge if and when we get to it.

This PR will also have an accompanying PR for the frontend repo, I'll update this description with a link to that PR when it goes up.

**Edit:** frontend PR is up at BitMEX/frontend#1626