### PR TITLE
[V2][Android] backgrounding bug fix

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
@@ -72,9 +72,15 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
 
     @Override
     public void invokeDefaultOnBackPressed() {
-        if (!navigator.handleBack(new CommandListenerAdapter())) {
-            super.onBackPressed();
+        if (navigator.handleBack(new CommandListenerAdapter())) {
+            return;
         }
+        final NavigationApplication application = app();
+        if (application != null && application.backButtonBackgroundsTaskOnEmptyStack()) {
+            this.moveTaskToBack(true);
+            return;
+        }
+        super.onBackPressed();
     }
 
     @Override

--- a/lib/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
@@ -86,4 +86,14 @@ public abstract class NavigationApplication extends Application implements React
     public final Map<String, ExternalComponentCreator> getExternalComponents() {
         return externalComponents;
     }
+
+    /**
+     * Determines whether pressing the back button should background the activity when the
+     * navigation stack is empty; override and return true to cause this behavior, otherwise
+     * by default pressing the back button will close the app when the nav stack is empty
+     * @return false for default behavior, true to background the task
+     */
+    protected boolean backButtonBackgroundsTaskOnEmptyStack() {
+        return false;
+    }
 }


### PR DESCRIPTION
This adds an additional flag that concrete implementations of `NavigationApplication` can override to change the behavior of the back button; originally, pressing the back button will close the application when the navigation stack is empty. This flag allows changing the behavior of the back button, so that the application will be moved to the background without closing in the event of a back button press on an empty nav stack. 

This fixes an issue where an app closed via the back button will hang at the splash screen when reopened.

This PR will have a frontend counterpart to add an override of the flag to our concrete impl of `NavigationApplication`; I'll update with a link to said PR when it goes up.

Edit: the frontend PR can be found at BitMEX/frontend#1638